### PR TITLE
46 - Add gnome version 41 to metadata

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -10,5 +10,5 @@
     "41"
   ],
   "url": "https://github.com/raujonas/executor",
-  "version": 16
+  "version": 17
 }

--- a/metadata.json
+++ b/metadata.json
@@ -6,7 +6,8 @@
     "3.30.2",
     "3.36",
     "3.38",
-    "40"
+    "40",
+    "41"
   ],
   "url": "https://github.com/raujonas/executor",
   "version": 16


### PR DESCRIPTION
- Add gnome version 41 to metadata (closes #46)