### PR TITLE
add gnome 44 support v21

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -9,8 +9,9 @@
     "40",
     "41",
     "42",
-    "43"
+    "43",
+    "44"
   ],
   "url": "https://github.com/raujonas/executor",
-  "version": 20
+  "version": 21
 }


### PR DESCRIPTION
Hello,

Thank you for the extension, it's really helpful.

I've a very simple use case with shell conditions, I've been using on Gnome 44 (Fedora 38 Beta) without problems.

Tested a little bit, sounds good.
I didn't test with any custom CSS.

Cheers,