### PR TITLE
Add support for gnome 46

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -8,5 +8,5 @@
     "46"
   ],
   "url": "https://github.com/raujonas/executor",
-  "version": 25
+  "version": 26
 }

--- a/metadata.json
+++ b/metadata.json
@@ -4,7 +4,8 @@
   "uuid": "executor@raujonas.github.io",
   "settings-schema": "org.gnome.shell.extensions.executor",
   "shell-version": [
-    "45"
+    "45",
+    "46"
   ],
   "url": "https://github.com/raujonas/executor",
   "version": 25


### PR DESCRIPTION
- Add new shell version to metadata
- Closes #78 