### PR TITLE
Add support for gnome 47

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -5,8 +5,9 @@
   "settings-schema": "org.gnome.shell.extensions.executor",
   "shell-version": [
     "45",
-    "46"
+    "46",
+    "47"
   ],
   "url": "https://github.com/raujonas/executor",
-  "version": 26
+  "version": 27
 }


### PR DESCRIPTION
- Update shell version in metadata.
- Bump extensions version.
- Closes #85 