### PR TITLE
Add gnome shell version 49 to metadata and bump version

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -7,8 +7,9 @@
     "45",
     "46",
     "47",
-    "48"
+    "48",
+    "49"
   ],
   "url": "https://github.com/raujonas/executor",
-  "version": 28
+  "version": 29
 }


### PR DESCRIPTION
- Add support for gnome shell version 49.
- Bump extension version to 29.
- Closes #91 